### PR TITLE
feat: Allow specifying cargo-binstall version on cargo-lambda dev feature

### DIFF
--- a/src/cargo-lambda/devcontainer-feature.json
+++ b/src/cargo-lambda/devcontainer-feature.json
@@ -8,6 +8,11 @@
             "type": "string",
             "default": "latest",
             "description": "Version of cargo lambda to install"
+        },
+        "binstall-version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of cargo-binstall to install"
         }
     },
     "dependsOn": {

--- a/src/cargo-lambda/install.sh
+++ b/src/cargo-lambda/install.sh
@@ -9,9 +9,12 @@ fi
 
 dpkg -l | grep build-essential || (apt update && apt install build-essential -y -qq)
 
-
 if ! cargo install --list | grep "cargo-binstall" > /dev/null; then
-    cargo install cargo-binstall
+    if [ -z "${BINSTALL_VERSION}" ] || [ "${BINSTALL_VERSION}" = "latest" ]; then
+        cargo install cargo-binstall
+    else
+        cargo install cargo-binstall --version ${BINSTALL_VERSION}
+    fi
 fi
 
 umask 002

--- a/test/cargo-lambda/scenarios.json
+++ b/test/cargo-lambda/scenarios.json
@@ -6,5 +6,14 @@
                 "version": "1.6.0"
             }
         }
+    },
+    "versioned-binstall": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "cargo-lambda": {
+                "version": "1.6.0",
+                "binstall-version": "1.3.0"
+            }
+        }
     }
 }

--- a/test/cargo-lambda/versioned-binstall.sh
+++ b/test/cargo-lambda/versioned-binstall.sh
@@ -10,7 +10,8 @@ source dev-container-features-test-lib
 # Feature-specific tests
 # The 'check' command comes from the dev-container-features-test-lib.
 # check <LABEL> <cmd> [args...]
-check "cargo lambda installed with 1.6.0" bash -c "cargo lambda --version" | grep -oP '\d+\.\d+\.\d+'
+check "cargo lambda installed with 1.6.0" bash -c "cargo lambda --version" | grep -oP '\d+\.\d+\.\d+' | grep 1.6.0
+check "cargo binstall installed with 1.3.0" bash -c "cargo binstall --version" | grep -oP '\d+\.\d+\.\d+' | grep 1.3.0
 
 # Report results
 # If any of the checks above exited with a non-zero exit code, the test will fail.


### PR DESCRIPTION
## Description

Add biinstall version when downloading binstall for cargo-lambda dev feature

Technically we can have a PR on allowing binstall versioning on https://github.com/lee-orr/rusty-dev-containers
but I want this fast